### PR TITLE
Prevents image filenames to be printed

### DIFF
--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -240,7 +240,7 @@ DataDirectory.prototype.initialiseHandlebars = function() {
   Handlebars.registerHelper('entry_thumbnail_bg', function(entry) {
     var thumbnail = entry[_this.config.thumbnail_field];
 
-    if ((!thumbnail || !/^(http|https):\/\//.test(thumbnail)) && !Array.isArray(thumbnail)) {
+    if ((!thumbnail || !/^https?:\/\//.test(thumbnail)) && !Array.isArray(thumbnail)) {
       return '';
     }
 

--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -240,7 +240,7 @@ DataDirectory.prototype.initialiseHandlebars = function() {
   Handlebars.registerHelper('entry_thumbnail_bg', function(entry) {
     var thumbnail = entry[_this.config.thumbnail_field];
 
-    if (!thumbnail) {
+    if ((!thumbnail || !/^(http|https):\/\//.test(thumbnail)) && !Array.isArray(thumbnail)) {
       return '';
     }
 


### PR DESCRIPTION
If the directory is configured to show images, but the user doesn't select a folder where some of all the images are stored in our File Manager, some images would be added to the DOM as only the file name and extension, generating quite a lot of stress on our API.

This will fix the issue by ignoring images that don't have an URL or aren't images uploaded using the form builder.