### PR TITLE
Changed to different navstack reference

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -1,6 +1,6 @@
 /* Compatbility with new Drag & Drop interface */
 
-[data-fl-edit],
+.mode-interact [data-fl-edit],
 [data-fl-edit] .fl-widget-instance {
   position: static;
 }

--- a/js/interface.js
+++ b/js/interface.js
@@ -206,8 +206,7 @@ Fliplet.DataSources.get({
 
 
 function save(notifyComplete) {
-  $('.alert.error').html('');
-  $('.alert.error').removeClass('show');
+  $('.alert.error').html('').removeClass('show');
   var errors = false;
 
   dataDirectoryForm.saveDataDirectoryForm_();

--- a/js/interface.js
+++ b/js/interface.js
@@ -170,7 +170,7 @@ function attahObservers() {
           context: 'overlay',
           appId: Fliplet.Env.get('appId'),
           folder: filePickerData.selectFiles[0],
-          navStack: filePickerData.selectFiles[1]
+          navStack: filePickerData.selectFiles[0].navStackRef || {}
         }
       }
     });


### PR DESCRIPTION
Because we changed the navstack reference created by the file picker in https://github.com/Fliplet/fliplet-widget-file-picker/pull/25 we needed to update the code to be able to open the file manager in the correct folder