### PR TITLE
Repositions index list on resize and render

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -396,7 +396,6 @@ body.fl-minimal-padding .directory-filters {
   width: 20px;
   position: fixed;
   top: 50%;
-  right: 0;
   -webkit-transform: translate3d(0, -50%, 0);
   transform: translate3d(0, -50%, 0);
   cursor: default;
@@ -410,7 +409,6 @@ body.fl-minimal-padding .directory-filters {
 
 @media screen and (min-width:640px) {
   .list-index {
-    right: 66.667%;
     margin-top: 50px;
   }
   .directory-mobile-mode .list-index {

--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -389,7 +389,12 @@ DataDirectory.prototype.renderEntries = function() {
   this.renderIndexList();
 };
 
-DataDirectory.prototype.renderIndexList = function() {
+DataDirectory.prototype.placeIndexList = function () {
+  var $listIndex = this.$container.find('.directory-entries + .list-index');
+  $listIndex.css('left', Math.round($('.directory-entries ul').width()));
+};
+
+DataDirectory.prototype.renderIndexList = function () {
   if (!this.config.is_alphabetical) return;
 
   var $listIndex = this.$container.find('.directory-entries + .list-index');
@@ -402,6 +407,8 @@ DataDirectory.prototype.renderIndexList = function() {
   $(document).on('touchstart mousedown', '.list-index span', $.proxy(this.listIndexTouchStart, this))
     .on('touchmove  mousemove', '.list-index span', $.proxy(this.listIndexTouchMove, this))
     .on('touchend   mouseup', '.list-index span', $.proxy(this.listIndexTouchEnd, this));
+
+  this.placeIndexList();
 };
 
 DataDirectory.prototype.scrollToLetter = function(letter) {
@@ -577,6 +584,7 @@ DataDirectory.prototype.attachObservers = function() {
     _this.resizeSearch();
     _this.navHeight = $('.fl-viewport-header').height() || 0;
     _this.searchBarHeight = _this.$container.find('.directory-search').outerHeight();
+    _this.placeIndexList();
   });
   this.$container.find('.directory-search').on('click', function() {
     // Analytics - Track Event
@@ -1347,9 +1355,15 @@ DataDirectory.prototype.directoryNotConfigured = function() {
 
 DataDirectory.prototype.flViewportRedraw = function() {
   return new Promise(function (resolve, reject) {
-    $(document.body).css('-webkit-transform', 'scale(1)');
-    setTimeout(function() {
-      $(document.body).css('-webkit-transform', '');
+    $(document.body).css({
+      transform: 'scale(1)',
+      position: 'absolute'
+    });
+    setTimeout(function () {
+      $(document.body).css({
+        transform: '',
+        position: ''
+      });
       setTimeout(function () {
         resolve();
       }, 0);


### PR DESCRIPTION
Fixes this problem:

![image 2018-03-19 at 12 26 14 pm](https://user-images.githubusercontent.com/290733/37595469-d4fd2d34-2b70-11e8-9d70-248f5975fcb5.png)

So that the index list is placed next to the scrollbar instead of on top of it:

![screen shot 2018-03-19 at 12 26 26](https://user-images.githubusercontent.com/290733/37595481-e0304880-2b70-11e8-83d3-e7e04906440b.png)

The alphabet index also doesn't currently work on the web because it’s superimposed on top of the scrollbar. It should work on now.