### PR TITLE
Removing an unimportant piece of CSS

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -411,9 +411,6 @@ body.fl-minimal-padding .directory-filters {
   .list-index {
     margin-top: 50px;
   }
-  .directory-mobile-mode .list-index {
-    right: 0;
-  }
 }
 
 .list-index span {


### PR DESCRIPTION
.list-index is now positioned by JS