### PR TITLE
Ensures the preset filter mode sets the directory as search only

### DIFF
--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -1356,6 +1356,14 @@ DataDirectory.prototype.parseQueryVars = function() {
         }
         break;
       case 'open':
+        if (query.entryId) {
+          var $entry = this.$container.find('[data-type="entry"][data-source-entry-id="' + query.entryId + '"]');
+          if (!$entry.length) {
+            break;
+          }
+
+          this.openDataEntry(parseInt($entry.attr('data-index'), 10), 'entry', false);
+        }
         break;
     }
   } else if (!this.config.mobile_mode && this.deviceIsTablet && !this.config.search_only) {

--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -773,7 +773,7 @@ DataDirectory.prototype.activateSearch = function(options) {
     options.userTriggered = true;
   }
 
-  if (options.userTriggered) {
+  if (options.userTriggered && !this.config.search_only) {
     document.body.classList.add('fl-top-menu-hidden');
   }
 
@@ -1349,6 +1349,7 @@ DataDirectory.prototype.parseQueryVars = function() {
         if (query.field && query.value) {
           this.presetFilter(query.field, query.value);
         } else {
+          this.setConfig('search_only', true);
           this.activateSearch({
             userTriggered: false
           });


### PR DESCRIPTION
- Ensures the preset filter mode sets the directory as search only (ref. https://github.com/Fliplet/fliplet-studio/issues/2462)
- Also adds support for "open" action (beta) (see also https://github.com/Fliplet/fliplet-widget-advanced-directory/pull/61)