### PR TITLE
Ensures widget instance is editable

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -6,7 +6,8 @@
 }
 
 [data-fl-edit],
-[data-fl-edit] .fl-widget-instance {
+[data-fl-edit] .fl-widget-instance,
+.mode-interact .fl-widget-instance {
   position: static;
 }
 


### PR DESCRIPTION
### Follow-up PR

* https://github.com/Fliplet/fliplet-widget-data-directory/pull/111 Fixes a bug where users cannot edit data directories