### PR TITLE
Authenticates file URLs for File field types

### DIFF
--- a/js/build-directory.js
+++ b/js/build-directory.js
@@ -1152,7 +1152,8 @@ DataDirectory.prototype.getEntryField = function(entryIndex, fieldIndex, type) {
       valueHTML = Handlebars.templates['directoryFieldType-' + fieldType](value);
     }
   } else if (Array.isArray(value) && value.length && this.config.field_types[label] === 'file') {
-    valueHTML = Handlebars.templates['directoryFieldType-file'](value[0]);
+    var url = Handlebars.templates['directoryFieldType-file'](value[0]);
+    valueHTML = Fliplet.Media.authenticate ? Fliplet.Media.authenticate(url) : url;
   } else {
     valueHTML = '';
   }


### PR DESCRIPTION
### Issue

If an organization is encrypted, the file referenced in the directory needs to have authentication added so that files are accessible.