### PR TITLE
fix(DEV-1068): add missing page and dataSource references for clone remapping

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -53,6 +53,12 @@
   },
   "references": [
     "source:dataSource",
-    "folder.selectFiles.$.id:mediaFolder"
+    "folder.selectFiles.$.id:mediaFolder",
+    "chatLinkAction.page:page",
+    "addEntryLinkAction.page:page",
+    "editEntryLinkAction.page:page",
+    "addEntry.dataSourceId:dataSource",
+    "editEntry.dataSourceId:dataSource",
+    "deleteEntry.dataSourceId:dataSource"
   ]
 }


### PR DESCRIPTION
## Summary
- Add 3 page references: `chatLinkAction.page`, `addEntryLinkAction.page`, `editEntryLinkAction.page`
- Add 3 data source references: `addEntry.dataSourceId`, `editEntry.dataSourceId`, `deleteEntry.dataSourceId`

These settings store IDs via the link provider and data source picker but were never declared in `references`, causing cloned apps to retain source-app IDs.

## Test plan
- [ ] Clone an app with a Data Directory widget configured with chat/add/edit link actions
- [ ] Verify all page and data source references point to new cloned IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)